### PR TITLE
Replace implicit Squeel dependency with vanilla AR

### DIFF
--- a/lib/core/serialized_columns.rb
+++ b/lib/core/serialized_columns.rb
@@ -81,11 +81,13 @@ module Core
         end
 
         scope :"with_#{name}_present", -> do
-          where{ length(Squeel::Nodes::Stub.new(store_attribute).op('->', name.to_s)) > 0 }
+          # `?` is the Postgres hstore operator for hash key presence
+          where(":column_name ? :key", column_name: store_attribute, key: name).exists?
         end
 
         scope :"with_#{name}_value", ->(val) do
-          where{cast(Squeel::Nodes::Stub.new(store_attribute).op('->', name.to_s).as(sql_type)) == val}
+          # `@>` is the Postgres hstore "contains" operator and (in contrast to `->`) will use the column index for queries
+          where(":column_name @> hstore(:key, :value)", column_name: store_attribute, key: name, value: value)
         end
 
       end


### PR DESCRIPTION
This project has an (undeclared) dependency on Squeel, which is not compatible with Rails > 4.

This replaces the Squeel usage with vanilla ActiveRecord queries, calling native Postgres hstore operators.

Note: this class has no tests and the only practical way to test it is by inclusion into a dependent project. For this case, I'm going to merge this into the `upgrade/rails-6` branch and test it within the arcdata project that way. However, this change is useful independently of its inclusion in that branch, hence this separate PR.